### PR TITLE
[add] Because there is no markdownlint on the git hooks.

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn textlint './**/*.md'
+yarn markdownlint


### PR DESCRIPTION
```sh
$ yarn husky add .husky/pre-commit "yarn markdownlint"
```