### PR TITLE
[fix] 2022-10-19_mac-android-connect

### DIFF
--- a/gatsby-starter-blog/content/blog/2022-10-19_mac-android-connect/index.md
+++ b/gatsby-starter-blog/content/blog/2022-10-19_mac-android-connect/index.md
@@ -12,7 +12,7 @@ adb コマンドでいろいろ操作を行いたいため
 macOS の場合、 Homebrew で `android-platform-tools` をインストールすれば OK
 
 ```sh
-$ brew uninstall android-platform-tools
+$ brew install android-platform-tools --cask
 
 ==> Installing Cask android-platform-tools
 ==> Linking Binary 'sload_f2fs' to '/usr/local/bin/sload_f2fs'


### PR DESCRIPTION
I wrote an uninstall. So i fixed it.
I was able to install without the Cask option, but having the option is better.